### PR TITLE
Fix for the absolute paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ $ npm install gulp-filelist
 
 ```
 gulp
-  .src(['awesome.file', 'lame.file'], { absolute: true })
-  .pipe(require('gulp-filelist')('filelist.json'))
+  .src(['awesome.file', 'lame.file'])
+  .pipe(require('gulp-filelist')('filelist.json', { absolute: true }))
   .pipe(gulp.dest('out'))
 ```
 Outputs:

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function(out, options) {
     files.push(file);
     var path = file.path;
     if (!options.absolute) {
-      path = path.replace(new RegExp('^' + __dirname + '/'), '');
+      path = path.replace(new RegExp('^' + process.cwd() + '/'), '');
     }
     filePaths.push(path);
   };


### PR DESCRIPTION
Turning off absolute paths wasn't working for two reasons
1. the __dirname isn't the directory where the gulpfile is, it's the directory of the node package in node_modules
2. the documentation had the parameter in the wrong location

This pull request fixes both!
