### PR TITLE
Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,11 +10,8 @@ module.exports = function(out, options) {
 
   var onFile = function(file) {
     files.push(file);
-    var path = file.path;
-    if (!options.absolute) {
-      path = path.replace(new RegExp('^' + process.cwd() + '/'), '');
-    }
-    filePaths.push(path);
+    var path = options.absolute ? file.path : file.relative;
+    filePaths.push(path.replace(/\\/g, '/'));
   };
 
   var onEnd = function() {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,14 @@ module.exports = function(out, options) {
 
   var onFile = function(file) {
     files.push(file);
-    var path = options.absolute ? file.path : file.relative;
+    var path
+	if (options.absolute) {
+	  path = file.path;
+	}
+	else {
+	  path = file.path.replace(process.cwd(), '');
+	  path = path.replace(new RegExp('^[/\\\\]'), '');
+	}
     filePaths.push(path.replace(/\\/g, '/'));
   };
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "vinyl": "^0.4.2"
   },
   "devDependencies": {
+    "gulp": "^3.8.11",
     "mocha": "^1.21.4",
     "should": "^4.0.4"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -30,7 +30,7 @@ describe('gulp-filelist', function(done) {
       .pipe(gulp.dest('test'))
       .on('end', function(file) {
         var filelist = require(filelistPath);
-        filelist[0].should.equal(__dirname + '/test.file');
+        filelist[0].should.equal(__dirname.replace(/\\/g, '/') + '/test.file');
         fs.unlinkSync(filelistPath);
         done();
       });


### PR DESCRIPTION
I've updated the logic for relative paths and the tests, which pass under Windows and OSX.

I've left in the substitution of \ for / in Windows paths, as it matches my use case, although I'm not sure if that makes sense for others.
