### PR TITLE
Honor the cwd option passed to gulp.src

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ module.exports = function(out, options) {
 
   options = options || {};
 
-  var files = [];
   var fileList = [];
 
   return through.obj(function(file, enc, cb) {
@@ -23,8 +22,6 @@ module.exports = function(out, options) {
       cb(new gutil.PluginError(pkg.name, 'Streams not supported'));
       return;
     }
-
-    files.push(file);
 
     var filePath;
     if (options.absolute) {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = function(out, options) {
   var fileList = [];
 
   return through.obj(function(file, enc, cb) {
+
     if (file.isNull()) {
       cb(null, file);
       return;
@@ -29,7 +30,7 @@ module.exports = function(out, options) {
     } else if (options.flatten) {
       filePath = path.basename(file.path);
     } else {
-      filePath = path.relative(process.cwd(), file.path);
+      filePath = path.relative(file.cwd, file.path);
     }
     if (options.removeExtensions) {
       var extension = path.extname(filePath);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-filelist",
   "description": "Convert list of file paths in current stream to a JSON file.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Chris Roth <chris@cjroth.com>",
   "contributors": [
     {

--- a/test/test.js
+++ b/test/test.js
@@ -100,4 +100,21 @@ describe('gulp-filelist', function(done) {
 
   });
 
+  describe('cwd option when building the stream', function(done) {
+    it("should be honoured", function(done) {
+      var out = 'filelist-cwd.json';
+      var filelistPath = path.join(__dirname, out);
+      gulp
+        .src('test.file', { cwd: 'test/' })
+        .pipe(gulpFilelist(out))
+        .pipe(gulp.dest('test'))
+        .on('end', function() {
+          var filelist = require(filelistPath);
+          filelist[0].should.equal('test.file');
+          fs.unlinkSync(filelistPath);
+          done();
+        });
+    })
+  });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -51,7 +51,7 @@ describe('gulp-filelist', function(done) {
       });
   });
 
-  describe('should remove extensions when the removeExtensions option is true', function () {
+  describe('removeExtensions option', function () {
 
     it('should work without additional options', function(done) {
       var out = 'filelist-remove.json';


### PR DESCRIPTION
Adds support for streams built with the 'cwd' option. See unit test for an example.

The other 2 commits are small (unrelated) code improvements.
