### PR TITLE
Fixes #14: add relative option to preserve path in case of rename

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ module.exports = function(out, options) {
       filePath = path.normalize(file.path);
     } else if (options.flatten) {
       filePath = path.basename(file.path);
+    } else if (options.relative) {
+      filePath = file.relative;
     } else {
       filePath = path.relative(file.cwd, file.path);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -56,6 +56,22 @@ describe('gulp-filelist', function(done) {
       });
   });
 
+  it('should output relative file paths when the relative option is true', function(done) {
+    var out = 'filelist-relative.json';
+    var filelistPath = path.join(__dirname, out);
+    gulp
+      .src(source)
+      .pipe(gulpFilelist(out, { relative: true }))
+      .pipe(gulp.dest('test'))
+      .on('end', function(file) {
+        var filelist = require(filelistPath);
+        filelist[0].should.equal('file1.txt');
+        filelist[1].should.equal('file2.txt');
+        fs.unlinkSync(filelistPath);
+        done();
+      });
+  });
+
   describe('removeExtensions option', function () {
 
     it('should work without additional options', function(done) {


### PR DESCRIPTION
Hi! Here is a possible fix for the issue I opened related to renamed paths. Using file.relative preserves the renamed path as is. I did not change the default behavior due to risk of breaking existing users.

I added a test that exercises this path though it does not directly validate my particular scenario with gulp-rename since I was hesitant to add a dep just for the test. Please let me know if you have a suggestion for how to test this better.

Thanks for your consideration