### PR TITLE
Support multiple tokens with destRowTemplate

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,13 +41,13 @@ module.exports = function(out, options) {
       }
     }
     filePath = filePath.replace(/\\/g, '/');
-    
+
     if(options.destRowTemplate) {
-      fileList.push(options.destRowTemplate.replace('@filePath@', filePath));
+      fileList.push(options.destRowTemplate.replace(new RegExp('@filePath@', 'g'), filePath));
     } else {
       fileList.push(filePath);
-    }    
-    
+    }
+
     cb();
   }, function(cb) {
     var buffer = (options.destRowTemplate) ? new Buffer(fileList.join('')) : new Buffer(JSON.stringify(fileList, null, '  '));

--- a/test/test.js
+++ b/test/test.js
@@ -74,6 +74,24 @@ describe('gulp-filelist', function(done) {
       });
   });
 
+  it('should work with the destRowTemplate option containing the token twice', function (done) {
+    var out = 'filelist-dest-row-template-2.txt';
+    var filelistPath = path.join(__dirname, out);
+    gulp
+      .src(source)
+      .pipe(gulpFilelist(out, { destRowTemplate: "@filePath@ - @filePath@\r\n" }))
+      .pipe(gulp.dest('test'))
+      .on('end', function(file) {
+        var filelist = fs.readFileSync(filelistPath, 'UTF-8');
+        var fileRows = filelist.split('\r\n');
+        fileRows.should.containEql('test/fixtures/file1.txt - test/fixtures/file1.txt');
+        fileRows.should.containEql('test/fixtures/file2.txt - test/fixtures/file2.txt');
+        fs.unlinkSync(filelistPath);
+        done();
+      });
+  });
+
+
   it('should output relative file paths when the relative option is true', function(done) {
     var out = 'filelist-relative.json';
     var filelistPath = path.join(__dirname, out);


### PR DESCRIPTION
We needed a file list where the filename appears more than once but String.prototype.replace only does that for the first occurrence. Turning it into a regex with the global flag fixes this. Test included.