### PR TITLE
replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var pkg = require('./package');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var through = require('through2');
 var path = require('path');
 var File = require('vinyl');
@@ -20,7 +20,7 @@ module.exports = function(out, options) {
     }
 
     if (file.isStream()) {
-      cb(new gutil.PluginError(pkg.name, 'Streams not supported'));
+      cb(new PluginError(pkg.name, 'Streams not supported'));
       return;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,19 @@
             "dev": true,
             "optional": true
         },
+        "ansi-colors": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+            "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+            "requires": {
+                "ansi-wrap": "^0.1.0"
+            }
+        },
         "ansi-gray": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+            "dev": true,
             "requires": {
                 "ansi-wrap": "0.1.0"
             }
@@ -28,12 +37,14 @@
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
         },
         "ansi-styles": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
         },
         "ansi-wrap": {
             "version": "0.1.0",
@@ -58,8 +69,7 @@
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-            "dev": true
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
         },
         "arr-flatten": {
             "version": "1.1.0",
@@ -70,13 +80,13 @@
         "arr-union": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-            "dev": true
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
         },
         "array-differ": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+            "dev": true
         },
         "array-each": {
             "version": "1.0.1",
@@ -93,7 +103,8 @@
         "array-uniq": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
         },
         "array-unique": {
             "version": "0.3.2",
@@ -104,8 +115,7 @@
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-            "dev": true
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
         },
         "async": {
             "version": "1.5.2",
@@ -183,7 +193,8 @@
         "beeper": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+            "dev": true
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -245,6 +256,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
             "requires": {
                 "ansi-styles": "^2.2.1",
                 "escape-string-regexp": "^1.0.2",
@@ -299,7 +311,8 @@
         "color-support": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+            "dev": true
         },
         "commander": {
             "version": "2.3.0",
@@ -333,7 +346,8 @@
         "dateformat": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-            "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+            "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+            "dev": true
         },
         "debug": {
             "version": "2.6.9",
@@ -428,6 +442,7 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+            "dev": true,
             "requires": {
                 "readable-stream": "~1.1.9"
             }
@@ -444,7 +459,8 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
         },
         "escodegen": {
             "version": "1.8.1",
@@ -543,7 +559,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-            "dev": true,
             "requires": {
                 "assign-symbols": "^1.0.0",
                 "is-extendable": "^1.0.1"
@@ -553,7 +568,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -629,6 +643,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+            "dev": true,
             "requires": {
                 "ansi-gray": "^0.1.1",
                 "color-support": "^1.1.3",
@@ -888,6 +903,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+            "dev": true,
             "requires": {
                 "sparkles": "^1.0.0"
             }
@@ -932,6 +948,7 @@
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+            "dev": true,
             "requires": {
                 "array-differ": "^1.0.0",
                 "array-uniq": "^1.0.2",
@@ -957,6 +974,7 @@
                     "version": "0.5.3",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
                     "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+                    "dev": true,
                     "requires": {
                         "clone": "^1.0.0",
                         "clone-stats": "^0.0.1",
@@ -969,6 +987,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+            "dev": true,
             "requires": {
                 "glogg": "^1.0.0"
             }
@@ -1012,6 +1031,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -1026,6 +1046,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+            "dev": true,
             "requires": {
                 "sparkles": "^1.0.0"
             }
@@ -1235,7 +1256,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -1273,7 +1293,8 @@
         "isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -1284,8 +1305,7 @@
         "isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-            "dev": true
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "istanbul": {
             "version": "0.4.5",
@@ -1422,52 +1442,62 @@
         "lodash._basecopy": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+            "dev": true
         },
         "lodash._basetostring": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+            "dev": true
         },
         "lodash._basevalues": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+            "dev": true
         },
         "lodash._getnative": {
             "version": "3.9.1",
             "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+            "dev": true
         },
         "lodash._isiterateecall": {
             "version": "3.0.9",
             "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+            "dev": true
         },
         "lodash._reescape": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+            "dev": true
         },
         "lodash._reevaluate": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+            "dev": true
         },
         "lodash._reinterpolate": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+            "dev": true
         },
         "lodash._root": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+            "dev": true
         },
         "lodash.escape": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+            "dev": true,
             "requires": {
                 "lodash._root": "^3.0.0"
             }
@@ -1475,17 +1505,20 @@
         "lodash.isarguments": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+            "dev": true
         },
         "lodash.isarray": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+            "dev": true
         },
         "lodash.keys": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+            "dev": true,
             "requires": {
                 "lodash._getnative": "^3.0.0",
                 "lodash.isarguments": "^3.0.0",
@@ -1495,12 +1528,14 @@
         "lodash.restparam": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+            "dev": true
         },
         "lodash.template": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+            "dev": true,
             "requires": {
                 "lodash._basecopy": "^3.0.0",
                 "lodash._basetostring": "^3.0.0",
@@ -1517,6 +1552,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+            "dev": true,
             "requires": {
                 "lodash._reinterpolate": "^3.0.0",
                 "lodash.escape": "^3.0.0"
@@ -1585,7 +1621,8 @@
         "minimist": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "dev": true
         },
         "mixin-deep": {
             "version": "1.3.1",
@@ -1716,6 +1753,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
             "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+            "dev": true,
             "requires": {
                 "duplexer2": "0.0.2"
             }
@@ -1758,7 +1796,8 @@
         "object-assign": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-            "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+            "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+            "dev": true
         },
         "object-copy": {
             "version": "0.1.0",
@@ -1960,6 +1999,17 @@
             "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
             "dev": true
         },
+        "plugin-error": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+            "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+            "requires": {
+                "ansi-colors": "^1.0.1",
+                "arr-diff": "^4.0.0",
+                "arr-union": "^3.1.0",
+                "extend-shallow": "^3.0.2"
+            }
+        },
         "posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -1992,6 +2042,7 @@
             "version": "1.1.14",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
             "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -2291,7 +2342,8 @@
         "sparkles": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
+            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+            "dev": true
         },
         "split-string": {
             "version": "3.1.0",
@@ -2338,12 +2390,14 @@
         "string_decoder": {
             "version": "0.10.31",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
         },
         "strip-ansi": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -2361,7 +2415,8 @@
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
         },
         "through2": {
             "version": "2.0.3",
@@ -2380,7 +2435,7 @@
                 "readable-stream": {
                     "version": "2.3.6",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -2413,7 +2468,8 @@
         "time-stamp": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+            "dev": true
         },
         "to-object-path": {
             "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,103 +1,103 @@
 {
-    "name": "gulp-filelist",
-    "description": "Output list of files in current stream to JSON file or custom format.",
-    "version": "1.1.0",
-    "author": {
-        "name": "Chris Roth",
-        "url": "https://github.com/cjroth",
-        "email": "chris@cjroth.com"
+  "name": "gulp-filelist",
+  "description": "Output list of files in current stream to JSON file or custom format.",
+  "version": "1.1.0",
+  "author": {
+    "name": "Chris Roth",
+    "url": "https://github.com/cjroth",
+    "email": "chris@cjroth.com"
+  },
+  "contributors": [
+    {
+      "name": "Alex DeJarnatt",
+      "url": "https://github.com/alexdej"
     },
-    "contributors": [
-        {
-            "name": "Alex DeJarnatt",
-            "url": "https://github.com/alexdej"
-        },
-        {
-            "name": "Andrea Paciolla",
-            "email": "andreapaciolla@gmail.com",
-            "url": "https://github.com/AndreaPaciolla"
-        },
-        {
-            "name": "Bach Ly",
-            "url": "https://github.com/bachly"
-        },
-        {
-            "name": "chewiebug",
-            "url": "https://github.com/chewiebug"
-        },
-        {
-            "name": "Colm McBarron",
-            "url": "https://github.com/ColmMcBarron"
-        },
-        {
-            "name": "Florian Wendelborn",
-            "email": "florianwendgithub@gmail.com",
-            "url": "https://github.com/dodekeract"
-        },
-        {
-            "name": "Ian Renyard",
-            "url": "https://github.com/renyard"
-        },
-        {
-            "name": "Maxwell Barvian",
-            "email": "max@barvian.me",
-            "url": "https://github.com/barvian"
-        },
-        {
-            "name": "Niko Salminen",
-            "email": "niko@salminen.me",
-            "url": "https://github.com/Kaivosukeltaja"
-        },
-        {
-            "name": "Paul Apostol",
-            "url": "https://github.com/devel-pa"
-        },
-        {
-            "name": "Paul Welsh",
-            "email": "spacedawwwg@gmail.com",
-            "url": "https://github.com/spacedawwwg"
-        },
-        {
-            "name": "Sebastián González",
-            "url": "https://github.com/tagae"
-        },
-        {
-            "name": "Vlad Bondarenko",
-            "url": "https://github.com/treago"
-        }
-    ],
-    "bugs": "https://github.com/cjroth/gulp-filelist/issues",
-    "dependencies": {
-        "gulp-util": "^3.0.7",
-        "path": "^0.12.7",
-        "through2": "^2.0.0",
-        "vinyl": "^1.1.0"
+    {
+      "name": "Andrea Paciolla",
+      "email": "andreapaciolla@gmail.com",
+      "url": "https://github.com/AndreaPaciolla"
     },
-    "devDependencies": {
-        "gulp": "^3.8.11",
-        "istanbul": "^0.4.5",
-        "mocha": "^1.21.4",
-        "should": "^4.0.4"
+    {
+      "name": "Bach Ly",
+      "url": "https://github.com/bachly"
     },
-    "engines": {
-        "node": ">= 0.8"
+    {
+      "name": "chewiebug",
+      "url": "https://github.com/chewiebug"
     },
-    "homepage": "https://github.com/cjroth/gulp-filelist/",
-    "keywords": [
-        "gulp",
-        "gulpplugin",
-        "extension",
-        "absolute",
-        "path",
-        "combine",
-        "json"
-    ],
-    "license": "MIT",
-    "main": "index.js",
-    "repository": "https://github.com/cjroth/gulp-filelist.git",
-    "scripts": {
-        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
-        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
-        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+    {
+      "name": "Colm McBarron",
+      "url": "https://github.com/ColmMcBarron"
+    },
+    {
+      "name": "Florian Wendelborn",
+      "email": "florianwendgithub@gmail.com",
+      "url": "https://github.com/dodekeract"
+    },
+    {
+      "name": "Ian Renyard",
+      "url": "https://github.com/renyard"
+    },
+    {
+      "name": "Maxwell Barvian",
+      "email": "max@barvian.me",
+      "url": "https://github.com/barvian"
+    },
+    {
+      "name": "Niko Salminen",
+      "email": "niko@salminen.me",
+      "url": "https://github.com/Kaivosukeltaja"
+    },
+    {
+      "name": "Paul Apostol",
+      "url": "https://github.com/devel-pa"
+    },
+    {
+      "name": "Paul Welsh",
+      "email": "spacedawwwg@gmail.com",
+      "url": "https://github.com/spacedawwwg"
+    },
+    {
+      "name": "Sebastián González",
+      "url": "https://github.com/tagae"
+    },
+    {
+      "name": "Vlad Bondarenko",
+      "url": "https://github.com/treago"
     }
+  ],
+  "bugs": "https://github.com/cjroth/gulp-filelist/issues",
+  "dependencies": {
+    "path": "^0.12.7",
+    "plugin-error": "^1.0.1",
+    "through2": "^2.0.0",
+    "vinyl": "^1.1.0"
+  },
+  "devDependencies": {
+    "gulp": "^3.8.11",
+    "istanbul": "^0.4.5",
+    "mocha": "^1.21.4",
+    "should": "^4.0.4"
+  },
+  "engines": {
+    "node": ">= 0.8"
+  },
+  "homepage": "https://github.com/cjroth/gulp-filelist/",
+  "keywords": [
+    "gulp",
+    "gulpplugin",
+    "extension",
+    "absolute",
+    "path",
+    "combine",
+    "json"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": "https://github.com/cjroth/gulp-filelist.git",
+  "scripts": {
+    "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+    "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+    "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,31 @@
+var pkg = require('../package');
 var fs = require('fs');
 var path = require('path');
 var gulp = require('gulp');
 var gulpFilelist = require('..');
+var assert = require('assert');
 
 var source = 'test/fixtures/*.txt';
 
 describe('gulp-filelist', function(done) {
+
+  it('should return an error, if used with a stream', function (done) {
+    var out = 'filelist-dest-row-template-function.txt';
+    var filelistPath = path.join(__dirname, out);
+    gulp
+      .src(source, {buffer: false})
+      .pipe(gulpFilelist(out)
+        .on('error', function(error) {
+          error.plugin.should.equal(pkg.name);
+          error.message.should.equal('Streams not supported');
+          done();
+        }))
+      .pipe(gulp.dest('test'))
+      .on('end', function(file) {
+        fs.unlinkSync(filelistPath);
+        assert.fail('there should have been an error');
+      });
+  });
 
   it('should output a json file with a list of the files currently in the stream', function(done) {
     var out = 'filelist.json';


### PR DESCRIPTION
https://github.com/gulpjs/gulp-util is marked as deprecated, reasons are explained here: https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5

I have replaced gulp-util with plugin-error (the only part of gulp-util, that was used).